### PR TITLE
added version to requirements.txt in Controller service

### DIFF
--- a/Controller-Service/requirements.txt
+++ b/Controller-Service/requirements.txt
@@ -17,4 +17,4 @@ googleads
 google-cloud-bigquery
 google-cloud-firestore
 google-cloud-logging
-google-cloud-tasks
+google-cloud-tasks==1.5.0


### PR DESCRIPTION
added version 1.5.0 to the controller service requirements file as 2.0.0 was being installed in some instances and client library references were causing errors